### PR TITLE
interleave cotruncates its arguments. interpose is saner now: #3

### DIFF
--- a/src/series-functions.lisp
+++ b/src/series-functions.lisp
@@ -190,16 +190,16 @@
   (interleave (scan (fset:convert 'cl:vector sequence1)) sequence2))
 
 (defmethod interleave ((sequence1 foundation-series)(sequence2 foundation-series)) 
-  (series:mingle sequence1 sequence2 (%make-toggle)))
+  (multiple-value-call #'series:mingle
+    (cotruncate sequence1 sequence2) (%make-toggle)))
 
 ;;; function interpose
 ;;;
 ;;; (interpose item sequence) => sequence'
 ;;; ---------------------------------------------------------------------
 
-(defmethod interpose (item (sequence foundation-series)) 
-  (let ((items (repeat item)))
-    (interleave sequence items)))
+(defmethod interpose ((item t) (sequence foundation-series))
+  (subseries (interleave (repeat item) sequence) 1))
 
 ;;; function partition 
 ;;;

--- a/src/series-package.lisp
+++ b/src/series-package.lisp
@@ -13,7 +13,7 @@
 (defpackage :net.bardcode.folio2.series
   (:use :cl :net.bardcode.folio2.as :net.bardcode.folio2.make)
   (:import-from :fset :wb-seq)
-  (:import-from :series :foundation-series)
+  (:import-from :series :foundation-series :cotruncate :subseries)
   (:import-from :net.bardcode.folio2.pairs :left :pair :right)
   (:shadowing-import-from :net.bardcode.folio2.sequences
                           :add-first :add-last :any :append :apportion :assoc


### PR DESCRIPTION
It would make more sense for `interleave` to cotruncate its arguments. This would also resolve #3.

To mind corner cases:
```lisp
(interpose 'item (scan nil))
=> #Z()
```

```lisp
(interpose 'item (scan '(x)))
=> #Z(X)
```

Interposed item never appears as the last (or first) element of series. This is in correspondence with
```lisp
(interpose 'item nil)
=> NIL
```

```lisp
(interpose 'item '(x))
=> (X)
```

Similarly, `interleave`'s effect on series is now more in tune with `interleave`'s other methods:
```lisp
(interleave '(a b c) '(x y))
=> (A X B Y)
(interleave (scan '(a b c)) (scan '(x y)))
=> #Z(A X B Y)
; used to be #Z(A X B Y C)
```

Note also that it might be desirable for `(interpose 'item (scan nil))` to evaluate to `NIL` as well. But it might be more natural if SERIES package itself adhered to this convention. This is a general issue with generalised sequences in Common Lisp.